### PR TITLE
Fix some ambiguity in . caused by broad imports.

### DIFF
--- a/src/Geodetics/Geodetic.hs
+++ b/src/Geodetics/Geodetic.hs
@@ -26,7 +26,7 @@ import Data.Monoid
 import Geodetics.Altitude
 import Geodetics.Ellipsoids
 import Geodetics.LatLongParser
-import Numeric.Units.Dimensional.Prelude
+import Numeric.Units.Dimensional.Prelude hiding ((.))
 import Text.ParserCombinators.ReadP
 import qualified Prelude as P
 

--- a/src/Geodetics/Grid.hs
+++ b/src/Geodetics/Grid.hs
@@ -26,7 +26,7 @@ import Data.Function
 import Data.Monoid
 import Geodetics.Altitude
 import Geodetics.Geodetic
-import Numeric.Units.Dimensional.Prelude
+import Numeric.Units.Dimensional.Prelude hiding ((.))
 import qualified Prelude as P
 
 -- | A Grid is a two-dimensional projection of the ellipsoid onto a plane. Any given type of grid can

--- a/src/Geodetics/TransverseMercator.hs
+++ b/src/Geodetics/TransverseMercator.hs
@@ -10,7 +10,7 @@ import Data.Monoid
 import Geodetics.Ellipsoids
 import Geodetics.Geodetic
 import Geodetics.Grid
-import Numeric.Units.Dimensional.Prelude
+import Numeric.Units.Dimensional.Prelude hiding ((.))
 import Prelude ()
 
 -- | A Transverse Mercator projection gives an approximate mapping of the ellipsoid on to a 2-D grid. It models


### PR DESCRIPTION
The build no longer succeeds on recent stack LTS versions.  This
should at least get things functional again.

It seems there's a lot of stuff pulled in by broad, unqualified imports.  One of these modules exported a `.` which conflicts with prelude's `.`