### PR TITLE
Explicitly implement Semigroups for Monoids.

### DIFF
--- a/src/Geodetics/Ellipsoids.hs
+++ b/src/Geodetics/Ellipsoids.hs
@@ -40,6 +40,8 @@ module Geodetics.Ellipsoids (
 ) where
 
 import Data.Monoid
+import Data.Monoid (Monoid)
+import Data.Semigroup (Semigroup, (<>))
 import Numeric.Units.Dimensional
 import Numeric.Units.Dimensional.Prelude
 import Prelude ()  -- Numeric instances.
@@ -110,12 +112,14 @@ data Helmert = Helmert {
    helmertScale :: Dimensionless Double,  -- ^ Parts per million
    rX, rY, rZ :: Dimensionless Double } deriving (Eq, Show)
 
+instance Semigroup Helmert where
+    h1 <> h2 = Helmert (cX h1 + cX h2) (cY h1 + cY h2) (cZ h1 + cZ h2)
+                       (helmertScale h1 + helmertScale h2)
+                       (rX h1 + rX h2) (rY h1 + rY h2) (rZ h1 + rZ h2)
+
 instance Monoid Helmert where
    mempty = Helmert (0 *~ meter) (0 *~ meter) (0 *~ meter) _0 _0 _0 _0
-   mappend h1 h2 = Helmert (cX h1 + cX h2) (cY h1 + cY h2) (cZ h1 + cZ h2)
-                           (helmertScale h1 + helmertScale h2)
-                           (rX h1 + rX h2) (rY h1 + rY h2) (rZ h1 + rZ h2)
-
+   mappend = (<>)
 
 -- | The inverse of a Helmert transformation.
 inverseHelmert :: Helmert -> Helmert

--- a/src/Geodetics/Grid.hs
+++ b/src/Geodetics/Grid.hs
@@ -23,7 +23,8 @@ module Geodetics.Grid (
 
 import Data.Char
 import Data.Function
-import Data.Monoid
+import Data.Monoid (Monoid)
+import Data.Semigroup (Semigroup, (<>))
 import Geodetics.Altitude
 import Geodetics.Geodetic
 import Numeric.Units.Dimensional.Prelude hiding ((.))
@@ -69,11 +70,14 @@ data GridOffset = GridOffset {
    deltaEast, deltaNorth, deltaAltitude :: Length Double
 } deriving (Eq, Show)
 
+instance Semigroup GridOffset where
+  g1 <> g2 = GridOffset (deltaEast g1 + deltaEast g2)
+                        (deltaNorth g1 + deltaNorth g2)
+                        (deltaAltitude g1 + deltaAltitude g2)
+
 instance Monoid GridOffset where
    mempty = GridOffset _0 _0 _0
-   mappend g1 g2 = GridOffset (deltaEast g1 + deltaEast g2) 
-                              (deltaNorth g1 + deltaNorth g2) 
-                              (deltaAltitude g1 + deltaAltitude g2) 
+   mappend = (<>)
 
 -- | An offset defined by a distance and a bearing to the right of North.
 --


### PR DESCRIPTION
Recent versions of Haskell have separated Semigroup out of Monoid such
that in order for a type to be monoidal it must also be a semigroup.

In these recent versions, this means mappend is automatically defined
as <>, but for backwards compatibility, I have to implement both here.