### PR TITLE
Use checkers to validate monoid laws

### DIFF
--- a/geodetics.cabal
+++ b/geodetics.cabal
@@ -58,7 +58,8 @@ test-suite GeodeticTest
                    test-framework >= 0.4.1,
                    test-framework-quickcheck2,
                    test-framework-hunit,
-                   array >= 0.4
+                   array >= 0.4,
+                   checkers
   hs-source-dirs:  
                    src, 
                    test


### PR DESCRIPTION
This looks happy with the latest changes.

```
GridOffset:
  monoid: left  identity: [OK, passed 1000 tests]
  monoid: right identity: [OK, passed 1000 tests]
  monoid: associativity: [OK, passed 1000 tests]
Helmert:
  monoid: left  identity: [OK, passed 1000 tests]
  monoid: right identity: [OK, passed 1000 tests]
  monoid: associativity: [OK, passed 1000 tests]
```