### PR TITLE
Remove unqualifed Monoid import from Ellipsoids

### DIFF
--- a/src/Geodetics/Ellipsoids.hs
+++ b/src/Geodetics/Ellipsoids.hs
@@ -39,7 +39,6 @@ module Geodetics.Ellipsoids (
    cross3
 ) where
 
-import Data.Monoid
 import Data.Monoid (Monoid)
 import Data.Semigroup (Semigroup, (<>))
 import Numeric.Units.Dimensional


### PR DESCRIPTION
This works in nightlies, but fails in older builds where monoids and
semigroups overlap.