### PR TITLE
Fix an example in the Haddock for `readGroundPosition`

### DIFF
--- a/src/Geodetics/Geodetic.hs
+++ b/src/Geodetics/Geodetic.hs
@@ -80,7 +80,7 @@ instance (Ellipsoid e) => Show (Geodetic e) where
 --
 -- * Decimal degrees NSEW: 34.52327N, 46.23234W
 --
--- * Degrees and decimal minutes (units optional): 34° 31.43' N, 46° 13.92' E
+-- * Degrees and decimal minutes (units optional): 34° 31.43' N, 46° 13.92' W
 --
 -- * Degrees, minutes and seconds (units optional): 34° 31' 23.52\" N, 46° 13' 56.43\" W
 --


### PR DESCRIPTION
I now realize that I made a mistake by adding “E” which should have been “W” to be in line with other examples.